### PR TITLE
435 feature prevent dupplicate login in same tab attempt number 2

### DIFF
--- a/apps/auth/api/views.py
+++ b/apps/auth/api/views.py
@@ -366,6 +366,14 @@ class DeleteApiView(APIView):
                     return Response({
                         "error": "You are currently in a tournament, please end it before deleting your account"
                     }, status=status.HTTP_401_UNAUTHORIZED)
+            if (redis.hexists(RTables.HASH_G_QUEUE, str(client.id))):
+                return Response({
+                    "error": "You are currently in queue, please leave it before deleting your account"
+                }, status=status.HTTP_401_UNAUTHORIZED)
+            if (redis.hexists(RTables.HASH_DUEL_QUEUE, str(client.id))):
+                return Response({
+                    "error": "You are currently in a duel queue, please leave it before deleting your account"
+                }, status=status.HTTP_401_UNAUTHORIZED)
             client.delete()
             RedisConnectionPool.close_sync_connection('api')
             return response

--- a/static/js/apps/game/matchmaking.js
+++ b/static/js/apps/game/matchmaking.js
@@ -52,8 +52,9 @@ const leftGameMessage = {
 }
 
 window.leftQueue = function () {
-    socket.send(JSON.stringify((leftGameMessage)));
-    // socket.close();
+    if (socket && WebSocketManager.isSocketOpen(socket)) {
+        socket.send(JSON.stringify((leftGameMessage)));
+    }
     navigateTo('/pong/gamemodes/');
 }
 
@@ -121,6 +122,18 @@ socket.onmessage = (e) => {
         toast_message("You are already in a game");
         navigateTo("/pong/gamemodes/");
     }
+    else if (jsonData.data.action == "JOINING_ERROR") {
+        WebSocketManager.closeGameSocket();
+        remove_toast();
+        toast_message("Error joining the queue");
+        navigateTo("/pong/gamemodes/");
+    } 
+    // else if (jsonData.data.action == "ALREADY_IN_QUEUE") {
+    //     WebSocketManager.closeGameSocket();
+    //     remove_toast();
+    //     toast_message("Error joining the queue");
+    //     navigateTo("/pong/gamemodes/");
+    // }
     ////// navigate to arena and then startGame would be better
     // if ()
 }

--- a/utils/jwt/JWT.py
+++ b/utils/jwt/JWT.py
@@ -86,7 +86,7 @@ class JWT:
                 raise jwt.InvalidTokenError(f'Validating token with type {token.TYPE} failed due to invalide token type.')
             return token
         except jwt.DecodeError as e:
-            raise jwt.InvalidTokenError(f'Error decoding token, it is either invalid or expired. {str(e)}') 
+            raise jwt.InvalidTokenError(f'Error decoding token, it is either invalid or expired')
         except jwt.ExpiredSignatureError as e:
             raise jwt.ExpiredSignatureError(f'Validating token with type {token_type.value} failed due to expired signature. {str(e)}')
         except (jwt.InvalidTokenError, jwt.DecodeError) as e:


### PR DESCRIPTION
I added a bunch of protections since I couldnt prevent two users from logging in.
Its not perfect at all but theres not error 500 I couldnt stop
Notorious list of bugs still in it : 
- If the users joins the queue twice, it effectively removes both tab from the queue, the user can back and queue again just fine, but theres no feedback on the frontend that this happened.
- Messing with duels breaks them for ever, it doesnt crash, but you can for ever not be able to do any duel anymore if you try to leave a dual game by joining matchmaking on another tab of the same browser.
- when joining the queue on another tab while ingame on the other, both players get the "Player disconnected" tab, this is just a visual bug, as the result is properly set later.